### PR TITLE
Refactor to enable multiple VMEC files.

### DIFF
--- a/Sources/CMakeLists.txt
+++ b/Sources/CMakeLists.txt
@@ -7,6 +7,7 @@ target_sources(bmw
                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/m_grid.f>
                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/primed_grid.f>
                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/siesta_file.f>
+               $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/vmec_file.f>
                $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/unprimed_grid.f>
 )
 

--- a/Sources/bmw.f
+++ b/Sources/bmw.f
@@ -121,11 +121,13 @@
       IF (cl_parser%is_flag_set('-mgridf')) THEN
          context => bmw_context_class(cl_parser%get('-mgridf'),                &
      &                                cl_parser%get('-woutf'),                 &
+     &                                cl_parser%get('-wvacf'),                 &
      &                                cl_parser%get('-siestaf'),               &
      &                                flags, num_p, parallel, io_unit)
       ELSE
          num_p = cl_parser%get('-num_p', 1)
          context => bmw_context_class(cl_parser%get('-woutf'),                 &
+     &                                cl_parser%get('-wvacf'),                 &
      &                                cl_parser%get('-siestaf'), flags,        &
      &                                cl_parser%get('-num_r', 1), num_p,       &
      &                                cl_parser%get('-num_z', 1),              &

--- a/Sources/bmw_commandline_parser.f
+++ b/Sources/bmw_commandline_parser.f
@@ -20,6 +20,7 @@
 !>     @item3{@fixed_width{-h},       N, Displays the help text and exits the program.}
 !>     @item3{@fixed_width{-mgridf},  Y, Specify the mgrid input file name.}
 !>     @item3{@fixed_width{-woutf},   Y, Specify the wout input file name.}
+!>     @item3{@fixed_width{-wvacf},   Y, Specify the vacuum wout input file name.}
 !>     @item3{@fixed_width{-siestaf}, Y, Specify the siesta input file name.}
 !>     @item3{@fixed_width{-outf},    Y, Specify the output input file name.}
 !>     @item3{@fixed_width{-logf},    Y, Write screen output to a log file.}
@@ -466,6 +467,7 @@
 !>
 !>    * -mgridf
 !>    * -woutf
+!>    * -wvacf
 !>    * -siestaf
 !>    * -outf
 !>    * -logf
@@ -492,7 +494,7 @@
 
       SELECT CASE (TRIM(this%arg(index)))
 
-         CASE ('-mgridf','-woutf','-siestaf','-outf','-logf')
+         CASE ('-mgridf','-woutf','-wvacf','-siestaf','-outf','-logf')
             IF (TRIM(this%value(index)) .eq. '') THEN
                WRITE (*,1000) TRIM(this%arg(index)),                           &
      &                        TRIM(this%arg(index))
@@ -538,6 +540,8 @@
       WRITE(*,*) '                                                     '
       WRITE(*,*) '  -woutf   Y Specify the wout file name.             '
       WRITE(*,*) '                                                     '
+      WRITE(*,*) '  -woutf   Y Specify the wout file name.             '
+      WRITE(*,*) '                                                     '
       WRITE(*,*) '  -siestaf Y Specify the siesta restart file name.   '
       WRITE(*,*) '             When this flag is used, plasma currents '
       WRITE(*,*) '             are computed from siesta fields instead '
@@ -553,24 +557,24 @@
       WRITE(*,*) '                                                     '
       WRITE(*,*) '  -ju      N Force balance j^u from curl derived j^v.'
       WRITE(*,*) '                                                     '
-!     WRITE(*,*) '  -p_start Y Starting phi index to compute fields. If'
-!     WRITE(*,*) '             this flag is not set, default to index  '
-!     WRITE(*,*) '             1.                                      '
-!     WRITE(*,*) '                                                     '
-!     WRITE(*,*) '  -p_end   Y Ending phi index to compute fields. If  '
-!     WRITE(*,*) '             this flag is not set, default to the    '
-!     WRITE(*,*) '             last index.                             '
-!     WRITE(*,*) '                                                     '
+      WRITE(*,*) '  -p_start Y Starting phi index to compute fields. If'
+      WRITE(*,*) '             this flag is not set, default to index  '
+      WRITE(*,*) '             1.                                      '
+      WRITE(*,*) '                                                     '
+      WRITE(*,*) '  -p_end   Y Ending phi index to compute fields. If  '
+      WRITE(*,*) '             this flag is not set, default to the    '
+      WRITE(*,*) '             last index.                             '
+      WRITE(*,*) '                                                     '
 !$    WRITE(*,*) '  -para    Y Determines number of threads threads to '
 !$    WRITE(*,*) '             run with. A value of -1 means use the   '
 !$    WRITE(*,*) '             default number of threads.              '
 !$    WRITE(*,*) '                                                     '
-!     WRITE(*,*) '  -force   N Force override of error conditions. To  '
-!     WRITE(*,*) '             prevent loss of valid data, BMW will    '
-!     WRITE(*,*) '             terminate if an error condition is      '
-!     WRITE(*,*) '             triggerd. This flag overrides that error'
-!     WRITE(*,*) '             potential overwritting valid data.      '
-!     WRITE(*,*) '                                                     '
+      WRITE(*,*) '  -force   N Force override of error conditions. To  '
+      WRITE(*,*) '             prevent loss of valid data, BMW will    '
+      WRITE(*,*) '             terminate if an error condition is      '
+      WRITE(*,*) '             triggerd. This flag overrides that error'
+      WRITE(*,*) '             potential overwritting valid data.      '
+      WRITE(*,*) '                                                     '
       WRITE(*,*) '  -num_r   Y Number radial points. Note not used when'
       WRITE(*,*) '             mgridf is specified.                    '
       WRITE(*,*) '                                                     '

--- a/Sources/m_grid.f
+++ b/Sources/m_grid.f
@@ -76,12 +76,14 @@
 !>  @param[in] mgrid_file_name File name for vacuum fields.
 !>  @param[in] parallel        @ref bmw_parallel_context_class object instance.
 !>  @param[in] io_unit         Unit number to write messages to.
+!>  @param[in] vmec            The vmec file object.
 !>  @returns A pointer to a constructed @ref m_grid_class object.
 !-------------------------------------------------------------------------------
-      FUNCTION m_grid_construct(mgrid_file_name, parallel, io_unit)
+      FUNCTION m_grid_construct(mgrid_file_name, parallel, io_unit,            &
+     &                          vmec)
       USE ezcdf
-      USE read_wout_mod, Only: extcur
       USE bmw_parallel_context
+      USE vmec_file
 
       IMPLICIT NONE
 
@@ -90,6 +92,7 @@
       CHARACTER (len=*), INTENT(in)                  :: mgrid_file_name
       CLASS (bmw_parallel_context_class), INTENT(in) :: parallel
       INTEGER, INTENT(in)                            :: io_unit
+      CLASS (vmec_file_class), POINTER, INTENT(in)   :: vmec
 
 !  local variables
       REAL (rprec)                                   :: start_time
@@ -149,21 +152,21 @@
 
       ALLOCATE(temp_buffer(num_r, num_z, num_p))
 
-      DO i = 1 + parallel%offset, SIZE(extcur), parallel%stride
+      DO i = 1 + parallel%offset, SIZE(vmec%extcur), parallel%stride
          WRITE (temp_string, 1000) i
          CALL cdf_read(mgrid_ncid, temp_string, temp_buffer)
          m_grid_construct%a_r = m_grid_construct%a_r                           &
-     &                        + temp_buffer*extcur(i)
+     &                        + temp_buffer*vmec%extcur(i)
 
          WRITE (temp_string, 1001) i
          CALL cdf_read(mgrid_ncid, temp_string, temp_buffer)
          m_grid_construct%a_p = m_grid_construct%a_p                           &
-     &                        + temp_buffer*extcur(i)
+     &                        + temp_buffer*vmec%extcur(i)
 
          WRITE (temp_string, 1002) i
          CALL cdf_read(mgrid_ncid, temp_string, temp_buffer)
          m_grid_construct%a_z = m_grid_construct%a_z                           &
-     &                        + temp_buffer*extcur(i)
+     &                        + temp_buffer*vmec%extcur(i)
       END DO
 
       IF (parallel%stride .gt. 1) THEN
@@ -207,13 +210,14 @@
 !>  @param[in] zmin     Minimum vertical position.
 !>  @param[in] parallel @ref bmw_parallel_context_class object instance.
 !>  @param[in] io_unit  Unit number to write messages to.
+!>  @param[in] vmec     The vmec file object.
 !>  @returns A pointer to a constructed @ref m_grid_class object.
 !-------------------------------------------------------------------------------
       FUNCTION m_grid_construct_plasma(num_r, num_p, num_z,                    &
      &                                 rmax, rmin, zmax, zmin,                 &
-     &                                 parallel, io_unit)
-      USE read_wout_mod, Only: nfp
+     &                                 parallel, io_unit, vmec)
       USE bmw_parallel_context
+      USE vmec_file
 
       IMPLICIT NONE
 
@@ -228,6 +232,7 @@
       REAL (rprec), INTENT(in)                       :: zmin
       CLASS (bmw_parallel_context_class), INTENT(in) :: parallel
       INTEGER, INTENT(in)                            :: io_unit
+      CLASS (vmec_file_class), POINTER, INTENT(in)   :: vmec
 
 !  local variables
       REAL (rprec)                                   :: start_time
@@ -237,7 +242,7 @@
 
       ALLOCATE(m_grid_construct_plasma)
 
-      m_grid_construct_plasma%nfp = nfp
+      m_grid_construct_plasma%nfp = vmec%nfp
 
       m_grid_construct_plasma%rmax = rmax
       m_grid_construct_plasma%zmax = zmax

--- a/Sources/siesta_file.f
+++ b/Sources/siesta_file.f
@@ -22,7 +22,7 @@
 
 !*******************************************************************************
 !  DERIVED-TYPE DECLARATIONS
-!  1) primed grid base class
+!  1) siesta file base class
 !
 !*******************************************************************************
 !-------------------------------------------------------------------------------
@@ -41,6 +41,18 @@
 
 !  Magnetic field scaling factor.
          REAL (rprec) :: b_factor
+
+!  Toroidal modes
+         REAL (rprec), DIMENSION(:), POINTER :: tor_modes => null()
+
+!  R half parity.
+         REAL (rprec), DIMENSION(:,:,:), POINTER :: rmncf => null()
+!  Z half parity.
+         REAL (rprec), DIMENSION(:,:,:), POINTER :: zmnsf => null()
+!  R full parity.
+         REAL (rprec), DIMENSION(:,:,:), POINTER :: rmnsf => null()
+!  Z full parity.
+         REAL (rprec), DIMENSION(:,:,:), POINTER :: zmncf => null()
 
 !  J^s current density half parity.
          REAL (rprec), DIMENSION(:,:,:), POINTER :: jksupsmnsf => null()
@@ -109,6 +121,18 @@
       CALL cdf_read(siesta_ncid, 'b_factor',                                   &
      &              siesta_file_construct%b_factor)
 
+      ALLOCATE(siesta_file_construct%tor_modes(                                &
+     &   -siesta_file_construct%ntor:siesta_file_construct%ntor))
+
+      ALLOCATE(siesta_file_construct%rmncf(                                    &
+     &   0:siesta_file_construct%mpol,                                         &
+     &   -siesta_file_construct%ntor:siesta_file_construct%ntor,               &
+     &   siesta_file_construct%nrad))
+      ALLOCATE(siesta_file_construct%zmnsf(                                    &
+     &   0:siesta_file_construct%mpol,                                         &
+     &   -siesta_file_construct%ntor:siesta_file_construct%ntor,               &
+     &   siesta_file_construct%nrad))
+
       ALLOCATE(siesta_file_construct%jksupsmnsf(                               &
      &   0:siesta_file_construct%mpol,                                         &
      &   -siesta_file_construct%ntor:siesta_file_construct%ntor,               &
@@ -122,6 +146,14 @@
      &   -siesta_file_construct%ntor:siesta_file_construct%ntor,               &
      &   siesta_file_construct%nrad))
 
+      CALL cdf_read(siesta_ncid, 'tor_modes',                                  &
+     &              siesta_file_construct%tor_modes)
+
+      CALL cdf_read(siesta_ncid, 'rmnc(m,n,r)',                                &
+     &              siesta_file_construct%rmncf)
+      CALL cdf_read(siesta_ncid, 'zmns(m,n,r)',                                &
+     &              siesta_file_construct%zmnsf)
+
       CALL cdf_read(siesta_ncid, 'jksupsmnsf(m,n,r)',                          &
      &              siesta_file_construct%jksupsmnsf)
       CALL cdf_read(siesta_ncid, 'jksupumncf(m,n,r)',                          &
@@ -130,6 +162,15 @@
      &              siesta_file_construct%jksupvmncf)
 
       IF (BTEST(siesta_file_construct%flags, siesta_lasym_flag)) THEN
+         ALLOCATE(siesta_file_construct%rmnsf(                                 &
+     &      0:siesta_file_construct%mpol,                                      &
+     &      -siesta_file_construct%ntor:siesta_file_construct%ntor,            &
+     &      siesta_file_construct%nrad))
+         ALLOCATE(siesta_file_construct%zmncf(                                 &
+     &      0:siesta_file_construct%mpol,                                      &
+     &      -siesta_file_construct%ntor:siesta_file_construct%ntor,            &
+     &      siesta_file_construct%nrad))
+
          ALLOCATE(siesta_file_construct%jksupsmncf(                            &
      &      0:siesta_file_construct%mpol,                                      &
      &      -siesta_file_construct%ntor:siesta_file_construct%ntor,            &
@@ -142,6 +183,11 @@
      &      0:siesta_file_construct%mpol,                                      &
      &      -siesta_file_construct%ntor:siesta_file_construct%ntor,            &
      &      siesta_file_construct%nrad))
+
+         CALL cdf_read(siesta_ncid, 'rmns(m,n,r)',                             &
+     &                 siesta_file_construct%rmnsf)
+         CALL cdf_read(siesta_ncid, 'zmnc(m,n,r)',                             &
+     &                 siesta_file_construct%zmncf)
 
          CALL cdf_read(siesta_ncid, 'jksupsmncf(m,n,r)',                       &
      &                 siesta_file_construct%jksupsmncf)
@@ -163,7 +209,7 @@
 !-------------------------------------------------------------------------------
 !>  @brief Deconstruct a @ref siesta_file_class object.
 !>
-!>  Deallocates memory and uninitializes a @ref m_grid_class object.
+!>  Deallocates memory and uninitializes a @ref siesta_file_class object.
 !>
 !>  @param[inout] this A @ref siesta_file_class instance.
 !-------------------------------------------------------------------------------
@@ -175,6 +221,31 @@
       TYPE (siesta_file_class), INTENT(inout) :: this
 
 !  Start of executable code
+      IF (ASSOCIATED(this%tor_modes)) THEN
+         DEALLOCATE(this%tor_modes)
+         this%tor_modes => null()
+      END IF
+
+      IF (ASSOCIATED(this%rmncf)) THEN
+         DEALLOCATE(this%rmncf)
+         this%rmncf => null()
+      END IF
+
+      IF (ASSOCIATED(this%zmnsf)) THEN
+         DEALLOCATE(this%zmnsf)
+         this%zmnsf => null()
+      END IF
+
+      IF (ASSOCIATED(this%rmnsf)) THEN
+         DEALLOCATE(this%rmnsf)
+         this%rmnsf => null()
+      END IF
+
+      IF (ASSOCIATED(this%zmncf)) THEN
+         DEALLOCATE(this%zmncf)
+         this%zmncf => null()
+      END IF
+
       IF (ASSOCIATED(this%jksupsmncf)) THEN
          DEALLOCATE(this%jksupsmncf)
          this%jksupsmncf => null()

--- a/Sources/vmec_file.f
+++ b/Sources/vmec_file.f
@@ -1,0 +1,307 @@
+!*******************************************************************************
+!>  @file vmec_file.f
+!>  @brief Contains module @ref vmec_file.
+!
+!  Note separating the Doxygen comment block here so detailed decription is
+!  found in the Module not the file.
+!
+!>  Defines the base class of the type @ref vmec_file_class. This contains the
+!>  output of a vmec equilibrium.
+!*******************************************************************************
+      MODULE vmec_file
+      USE stel_kinds, ONLY: rprec
+      USE profiler
+
+      IMPLICIT NONE
+
+!*******************************************************************************
+!  DERIVED-TYPE DECLARATIONS
+!  1) vmec file base class
+!
+!*******************************************************************************
+!-------------------------------------------------------------------------------
+!>  Base class representing a vmec output.
+!-------------------------------------------------------------------------------
+      TYPE vmec_file_class
+!  Number of radial points.
+         INTEGER :: ns
+
+!  Number of modes.
+         INTEGER :: mnmax
+!  Number of modes.
+         INTEGER :: isigng
+!  Number of field periods.
+         INTEGER :: nfp
+
+!  External current array.
+         REAL (rprec), DIMENSION(:), POINTER :: extcur => null()
+
+!  Poloidal mode spectrum.
+         REAL (rprec), DIMENSION(:), POINTER :: xm => null()
+!  Toroidal mode spectrum.
+         REAL (rprec), DIMENSION(:), POINTER :: xn => null()
+
+!  Number of nyquist modes.
+         INTEGER :: mnmax_nyq
+
+!  Poloidal mode nyquist spectrum.
+         REAL (rprec), DIMENSION(:), POINTER :: xm_nyq => null()
+!  Toroidal mode nyquist spectrum.
+         REAL (rprec), DIMENSION(:), POINTER :: xn_nyq => null()
+
+!  Flag to indicate stellarator symmetry.
+         LOGICAL :: lasym
+
+!  Pressure profile.
+         REAL (rprec), DIMENSION(:), POINTER :: presf => null()
+
+!  R half parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: rmncf => null()
+!  Z half parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: zmnsf => null()
+!  R full parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: rmnsf => null()
+!  Z full parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: zmncf => null()
+
+!  B^u half parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: bsupumnch => null()
+!  B^v half parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: bsupvmnch => null()
+!  B^u full parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: bsupumnsh => null()
+!  B^v full parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: bsupvmnsh => null()
+
+!  J^u current density half parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: jksupumncf => null()
+!  J^v current density half parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: jksupvmncf => null()
+!  J^u current density full parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: jksupumnsf => null()
+!  J^v current density full parity.
+         REAL (rprec), DIMENSION(:,:), POINTER :: jksupvmnsf => null()
+      CONTAINS
+         FINAL :: vmec_file_destruct
+      END TYPE
+
+!-------------------------------------------------------------------------------
+!>  Interface for the vmec_file_class constructor.
+!-------------------------------------------------------------------------------
+      INTERFACE vmec_file_class
+         MODULE PROCEDURE vmec_file_construct
+      END INTERFACE
+
+      CONTAINS
+!*******************************************************************************
+!  CONSTRUCTION SUBROUTINES
+!*******************************************************************************
+!-------------------------------------------------------------------------------
+!>  @brief Construct a @ref vmec_file_class object.
+!>
+!>  Allocates memory and initializes a @ref vmec_file_class object with an
+!>  siesta restart file.
+!>
+!>  @param[in] vmec_file_name File name for vacuum fields.
+!>  @returns A pointer to a constructed @ref vmec_file_class object.
+!-------------------------------------------------------------------------------
+      FUNCTION vmec_file_construct(vmec_file_name)
+      USE ezcdf
+
+      IMPLICIT NONE
+
+!  Declare Arguments
+      CLASS (vmec_file_class), POINTER :: vmec_file_construct
+      CHARACTER (len=*), INTENT(in)    :: vmec_file_name
+
+!  local variables
+      REAL (rprec)                     :: start_time
+      INTEGER                          :: vmec_ncid
+      INTEGER                          :: status
+      INTEGER                          :: nextcur
+
+!  Start of executable code
+      start_time = profiler_get_start_time()
+
+      ALLOCATE(vmec_file_construct)
+
+      CALL cdf_open(vmec_ncid, TRIM(vmec_file_name), 'r', status)
+
+      CALL cdf_read(vmec_ncid, 'ns', vmec_file_construct%ns)
+
+      CALL cdf_read(vmec_ncid, 'signgs', vmec_file_construct%isigng)
+      CALL cdf_read(vmec_ncid, 'nfp', vmec_file_construct%nfp)
+
+      CALL cdf_read(vmec_ncid, 'nextcur', nextcur)
+      ALLOCATE(vmec_file_construct%extcur(nextcur))
+      CALL cdf_read(vmec_ncid, 'extcur', vmec_file_construct%extcur)
+
+      CALL cdf_read(vmec_ncid, 'mnmax', vmec_file_construct%mnmax)
+      CALL cdf_read(vmec_ncid, 'mnmax_nyq',                                    &
+     &              vmec_file_construct%mnmax_nyq)
+
+      ALLOCATE(vmec_file_construct%xm(vmec_file_construct%mnmax))
+      ALLOCATE(vmec_file_construct%xn(vmec_file_construct%mnmax))
+
+      ALLOCATE(vmec_file_construct%xm_nyq(                                     &
+     &            vmec_file_construct%mnmax_nyq))
+      ALLOCATE(vmec_file_construct%xn_nyq(                                     &
+     &            vmec_file_construct%mnmax_nyq))
+
+      ALLOCATE(vmec_file_construct%presf(vmec_file_construct%ns))
+
+      ALLOCATE(vmec_file_construct%rmncf(                                      &
+     &   vmec_file_construct%ns, vmec_file_construct%mnmax))
+      ALLOCATE(vmec_file_construct%zmnsf(                                      &
+     &   vmec_file_construct%ns, vmec_file_construct%mnmax))
+
+      ALLOCATE(vmec_file_construct%bsupumnch(                                  &
+     &   vmec_file_construct%ns, vmec_file_construct%mnmax_nyq))
+      ALLOCATE(vmec_file_construct%bsupvmnch(                                  &
+     &   vmec_file_construct%ns, vmec_file_construct%mnmax_nyq))
+
+      ALLOCATE(vmec_file_construct%jksupumncf(                                 &
+     &   vmec_file_construct%ns, vmec_file_construct%mnmax_nyq))
+      ALLOCATE(vmec_file_construct%jksupvmncf(                                 &
+     &   vmec_file_construct%ns, vmec_file_construct%mnmax_nyq))
+
+      CALL cdf_read(vmec_ncid, 'xm', vmec_file_construct%xm)
+      CALL cdf_read(vmec_ncid, 'xn', vmec_file_construct%xn)
+
+      CALL cdf_read(vmec_ncid, 'xm_nyq', vmec_file_construct%xm_nyq)
+      CALL cdf_read(vmec_ncid, 'xn_nyq', vmec_file_construct%xn_nyq)
+
+      CALL cdf_read(vmec_ncid, 'presf', vmec_file_construct%presf)
+
+      CALL cdf_read(vmec_ncid, 'rmnc', vmec_file_construct%rmncf)
+      CALL cdf_read(vmec_ncid, 'zmns', vmec_file_construct%zmnsf)
+
+      CALL cdf_read(vmec_ncid, 'bsupumnc',                                     &
+     &              vmec_file_construct%bsupumnch)
+      CALL cdf_read(vmec_ncid, 'bsupvmnc',                                     &
+     &              vmec_file_construct%bsupvmnch)
+
+      CALL cdf_read(vmec_ncid, 'currumnc',                                     &
+     &              vmec_file_construct%jksupumncf)
+      CALL cdf_read(vmec_ncid, 'currvmnc',                                     &
+     &              vmec_file_construct%jksupvmncf)
+
+      CALL cdf_read(vmec_ncid, 'lasym', vmec_file_construct%lasym)
+
+      IF (vmec_file_construct%lasym) THEN
+         ALLOCATE(vmec_file_construct%rmnsf(                                   &
+     &      vmec_file_construct%ns, vmec_file_construct%mnmax))
+         ALLOCATE(vmec_file_construct%zmncf(                                   &
+     &      vmec_file_construct%ns, vmec_file_construct%mnmax))
+
+         ALLOCATE(vmec_file_construct%bsupumnsh(                               &
+     &      vmec_file_construct%ns, vmec_file_construct%mnmax_nyq))
+         ALLOCATE(vmec_file_construct%bsupvmnsh(                               &
+     &      vmec_file_construct%ns, vmec_file_construct%mnmax_nyq))
+
+         ALLOCATE(vmec_file_construct%jksupumnsf(                              &
+     &      vmec_file_construct%ns, vmec_file_construct%mnmax_nyq))
+         ALLOCATE(vmec_file_construct%jksupvmnsf(                              &
+     &      vmec_file_construct%ns, vmec_file_construct%mnmax_nyq))
+
+         CALL cdf_read(vmec_ncid, 'rmns', vmec_file_construct%rmnsf)
+         CALL cdf_read(vmec_ncid, 'zmnc', vmec_file_construct%zmncf)
+
+         CALL cdf_read(vmec_ncid, 'bsupumns',                                  &
+     &                 vmec_file_construct%bsupumnsh)
+         CALL cdf_read(vmec_ncid, 'bsupvmns',                                  &
+     &                 vmec_file_construct%bsupvmnsh)
+
+         CALL cdf_read(vmec_ncid, 'currumns',                                  &
+     &                 vmec_file_construct%jksupumnsf)
+         CALL cdf_read(vmec_ncid, 'currvmns',                                  &
+     &                 vmec_file_construct%jksupvmnsf)
+      END IF
+
+      CALL cdf_close(vmec_ncid)
+
+      CALL profiler_set_stop_time('vmec_file_construct', start_time)
+
+      END FUNCTION
+
+!*******************************************************************************
+!  DESTRUCTION SUBROUTINES
+!*******************************************************************************
+!-------------------------------------------------------------------------------
+!>  @brief Deconstruct a @ref vmec_file_class object.
+!>
+!>  Deallocates memory and uninitializes a @ref vmec_file_class object.
+!>
+!>  @param[inout] this A @ref vmec_file_class instance.
+!-------------------------------------------------------------------------------
+      SUBROUTINE vmec_file_destruct(this)
+
+      IMPLICIT NONE
+
+!  Declare Arguments
+      TYPE (vmec_file_class), INTENT(inout) :: this
+
+!  Start of executable code
+      IF (ASSOCIATED(this%xm)) THEN
+         DEALLOCATE(this%xm)
+         this%xm => null()
+      END IF
+
+      IF (ASSOCIATED(this%xn)) THEN
+         DEALLOCATE(this%xn)
+         this%xn => null()
+      END IF
+
+      IF (ASSOCIATED(this%xm_nyq)) THEN
+         DEALLOCATE(this%xm_nyq)
+         this%xm_nyq => null()
+      END IF
+
+      IF (ASSOCIATED(this%xn_nyq)) THEN
+         DEALLOCATE(this%xn_nyq)
+         this%xn_nyq => null()
+      END IF
+
+      IF (ASSOCIATED(this%rmncf)) THEN
+         DEALLOCATE(this%rmncf)
+         this%rmncf => null()
+      END IF
+
+      IF (ASSOCIATED(this%zmnsf)) THEN
+         DEALLOCATE(this%zmnsf)
+         this%zmnsf => null()
+      END IF
+
+      IF (ASSOCIATED(this%rmnsf)) THEN
+         DEALLOCATE(this%rmnsf)
+         this%rmnsf => null()
+      END IF
+
+      IF (ASSOCIATED(this%zmncf)) THEN
+         DEALLOCATE(this%zmncf)
+         this%zmncf => null()
+      END IF
+
+      IF (ASSOCIATED(this%jksupumncf)) THEN
+         DEALLOCATE(this%jksupumncf)
+         this%jksupumncf => null()
+      END IF
+
+      IF (ASSOCIATED(this%jksupvmncf)) THEN
+         DEALLOCATE(this%jksupvmncf)
+         this%jksupvmncf => null()
+      END IF
+
+      IF (ASSOCIATED(this%jksupumnsf)) THEN
+         DEALLOCATE(this%jksupumnsf)
+         this%jksupumnsf => null()
+      END IF
+
+      IF (ASSOCIATED(this%jksupvmnsf)) THEN
+         DEALLOCATE(this%jksupvmnsf)
+         this%jksupvmnsf => null()
+      END IF
+
+      END SUBROUTINE
+
+      END MODULE


### PR DESCRIPTION
This includes some temp constructors which break the surface code until. SIESTA  also uses a temp constructor but it should not affect anything.